### PR TITLE
Adds reset & fixes Typescript bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ An array containing the value, a function to set the value and another function 
 - `[1]` : A function to set the value stored in LocalStorage. Signature is exactly like the standard [React.useState](https://reactjs.org/docs/hooks-state.html) hook.
 - `[2]` : A function to reset the data stored in the LocalStorage.
 
-
-
 [npm-image]: https://img.shields.io/npm/v/@phntms/use-local-state.svg?style=flat-square&logo=react
 [npm-url]: https://npmjs.org/package/@phntms/use-local-state
 [npm-downloads-image]: https://img.shields.io/npm/dm/@phntms/use-local-state.svg

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Just swap out your `useState` calls with `useLocalState` to persist the data bet
 ```javascript
 import useLocalState from "@phntms/use-local-state";
 
-const [token, setToken] = useLocalState("USER_TOKEN", "");
+const [value, setValue, resetValue] = useLocalState("key", "");
 ```
 
 ## Installation
@@ -59,7 +59,7 @@ interface Bookmark {
 }
 
 const BookmarkExample = () = {
-  const [bookmarks, setBookmarks] = useLocalState<Bookmark[]>("BOOKMARKS", []);
+  const [bookmarks, setBookmarks, clearBookmarks] = useLocalState<Bookmark[]>("BOOKMARKS", []);
 
   const addBookmark = (bookmark: Bookmark) => setBookmarks([...bookmarks, bookmark]);
 
@@ -67,6 +67,7 @@ const BookmarkExample = () = {
     <>
       <h1>Bookmarks</h2>
       <NewBookmark add={addBookmark} />
+      <button onClick={clearBookmarks}>Clear Bookmarks</button>
       <ul>
         {bookmarks.map(((bookmark, i) => (
           <li key={i}>
@@ -88,7 +89,13 @@ const BookmarkExample = () = {
 
 ### Output
 
-An array containing the value and a function to set the value. Signature is exactly like the standard [React.useState](https://reactjs.org/docs/hooks-state.html) hook.
+An array containing the value, a function to set the value and another function to reset the value.
+
+- `[0]` : The value of the data stored in LocalStorage or the defaultValue if not set.
+- `[1]` : A function to set the value stored in LocalStorage. Signature is exactly like the standard [React.useState](https://reactjs.org/docs/hooks-state.html) hook.
+- `[2]` : A function to reset the data stored in the LocalStorage.
+
+
 
 [npm-image]: https://img.shields.io/npm/v/@phntms/use-local-state.svg?style=flat-square&logo=react
 [npm-url]: https://npmjs.org/package/@phntms/use-local-state

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Just swap out your `useState` calls with `useLocalState` to persist the data bet
 ```javascript
 import useLocalState from "@phntms/use-local-state";
 
-const [value, setValue, resetValue] = useLocalState("key", "");
+const [value, setValue, resetValue] = useLocalState("KEY", "");
 ```
 
 ## Installation

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,7 @@ const useLocalState = <S>(
   const [value, setValue] = useState<S>(() => {
     const isCallable = (value: unknown): value is () => S =>
       typeof value === "function";
-
     const toStore = isCallable(defaultValue) ? defaultValue() : defaultValue;
-
     if (!SUPPORTED) return toStore;
     const item = window.localStorage.getItem(key);
     try {
@@ -35,7 +33,6 @@ const useLocalState = <S>(
   const reset = () => {
     const isCallable = (value: unknown): value is (prevState: S) => S =>
       typeof value === "function";
-
     const toStore = isCallable(defaultValue) ? defaultValue() : defaultValue;
     setValue(toStore);
     if (SUPPORTED) window.localStorage.removeItem(key);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,19 @@ import { useState } from "react";
 
 import { SUPPORTED } from "./utils";
 
-const useLocalState = <T>(
+type Dispatch<A> = (value: A) => void;
+type SetStateAction<S> = S | ((prevState: S) => S);
+
+const useLocalState = <S>(
   key: string,
-  defaultValue: T
-): [T, (v: T | ((v: T) => T)) => void] => {
-  const [value, setValue] = useState<T>(() => {
-    const toStore =
-      typeof defaultValue === "function" ? defaultValue() : defaultValue;
+  defaultValue: S | (() => S)
+): [S, Dispatch<SetStateAction<S>>, () => void] => {
+  const [value, setValue] = useState<S>(() => {
+    const isCallable = (value: unknown): value is () => S =>
+      typeof value === "function";
+
+    const toStore = isCallable(defaultValue) ? defaultValue() : defaultValue;
+
     if (!SUPPORTED) return toStore;
     const item = window.localStorage.getItem(key);
     try {
@@ -18,15 +24,24 @@ const useLocalState = <T>(
     }
   });
 
-  const setLocalStateValue = (newValue: T | ((v: T) => T)) => {
-    const isCallable = (value: unknown): value is (v: T) => T =>
+  const setLocalStateValue = (newValue: SetStateAction<S>) => {
+    const isCallable = (value: unknown): value is (prevState: S) => S =>
       typeof value === "function";
     const toStore = isCallable(newValue) ? newValue(value) : newValue;
     if (SUPPORTED) window.localStorage.setItem(key, JSON.stringify(toStore));
     setValue(toStore);
   };
 
-  return [value, setLocalStateValue];
+  const reset = () => {
+    const isCallable = (value: unknown): value is (prevState: S) => S =>
+      typeof value === "function";
+
+    const toStore = isCallable(defaultValue) ? defaultValue() : defaultValue;
+    setValue(toStore);
+    if (SUPPORTED) window.localStorage.removeItem(key);
+  };
+
+  return [value, setLocalStateValue, reset];
 };
 
 export default useLocalState;

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -66,6 +66,23 @@ describe("useLocalState()", () => {
     expect(todos).toEqual(values);
   });
 
+  it("accepts callback as a defaultValue and can be updated with a simple type", async () => {
+    const key = "todos";
+    const values = ["first", "second"];
+    const callback = () => values;
+    const { result } = renderHook(() => useLocalState(key, callback));
+    expect(result.current[0]).toEqual(values);
+
+    const newValue = ["third", "fourth"];
+    act(() => {
+      const setValue = result.current[1];
+      setValue(newValue);
+    });
+
+    const [changedValues] = result.current;
+    expect(changedValues).toEqual(newValue);
+  });
+
   it("can update value as string", async () => {
     const key = "key";
     const value = "something";
@@ -243,7 +260,7 @@ describe("useLocalState()", () => {
     const key = "todos";
     const values = ["first", "second"];
     const callback = () => values;
-    const { result } = renderHook(() => useLocalState<string[]>(key, callback));
+    const { result } = renderHook(() => useLocalState(key, callback));
     expect(result.current[0]).toEqual(values);
 
     const newValue = ["third", "fourth"];

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -118,7 +118,6 @@ describe("useLocalState()", () => {
     expect(todos).toEqual(newValues);
   });
 
-  // todo(): this logic could be super handy...
   it("updates state with callback function", () => {
     const key = "todos";
     const values = ["first", "second"];
@@ -211,5 +210,59 @@ describe("useLocalState()", () => {
 
     const [value] = result.current;
     expect(value).toBe(null);
+  });
+
+  it("can reset to default value", async () => {
+    const key = "key";
+    const value = "something";
+
+    const { result } = renderHook(() => useLocalState(key, value));
+    expect(result.current[0]).toEqual(value);
+
+    const newValue = "something else";
+    act(() => {
+      const setValue = result.current[1];
+      setValue(newValue);
+    });
+
+    const [changedValues] = result.current;
+    expect(changedValues).toEqual(newValue);
+
+    act(() => {
+      const reset = result.current[2];
+      reset();
+    });
+
+    const [values] = result.current;
+    expect(values).toEqual(value);
+
+    expect(localStorage.getItem(key)).toEqual(null);
+  });
+
+  it("can reset to default value as callback", async () => {
+    const key = "todos";
+    const values = ["first", "second"];
+    const callback = () => values;
+    const { result } = renderHook(() => useLocalState<string[]>(key, callback));
+    expect(result.current[0]).toEqual(values);
+
+    const newValue = ["third", "fourth"];
+    act(() => {
+      const setValue = result.current[1];
+      setValue(newValue);
+    });
+
+    const [changedValues] = result.current;
+    expect(changedValues).toEqual(newValue);
+
+    act(() => {
+      const reset = result.current[2];
+      reset();
+    });
+
+    const [resetValues] = result.current;
+    expect(resetValues).toEqual(values);
+
+    expect(localStorage.getItem(key)).toEqual(null);
   });
 });

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -71,7 +71,9 @@ describe("useLocalState()", () => {
     const values = ["first", "second"];
     const callback = () => values;
     const { result } = renderHook(() => useLocalState(key, callback));
-    expect(result.current[0]).toEqual(values);
+
+    const [initialValues] = result.current;
+    expect(initialValues).toEqual(values);
 
     const newValue = ["third", "fourth"];
     act(() => {
@@ -86,9 +88,10 @@ describe("useLocalState()", () => {
   it("can update value as string", async () => {
     const key = "key";
     const value = "something";
-
     const { result } = renderHook(() => useLocalState(key, value));
-    expect(result.current[0]).toEqual(value);
+
+    const [initialValue] = result.current;
+    expect(initialValue).toEqual(value);
 
     const newValue = "something else";
     act(() => {
@@ -104,9 +107,10 @@ describe("useLocalState()", () => {
   it("can update value as object", async () => {
     const key = "key";
     const value = { something: "something" };
-
     const { result } = renderHook(() => useLocalState(key, value));
-    expect(result.current[0]).toEqual(value);
+
+    const [initialValue] = result.current;
+    expect(initialValue).toEqual(value);
 
     const newValue = { something: "else" };
     act(() => {
@@ -135,7 +139,7 @@ describe("useLocalState()", () => {
     expect(todos).toEqual(newValues);
   });
 
-  it("updates state with callback function", () => {
+  it("updates state with callback function", async () => {
     const key = "todos";
     const values = ["first", "second"];
     const { result } = renderHook(() => useLocalState(key, values));
@@ -198,7 +202,6 @@ describe("useLocalState()", () => {
   it("can handle `undefined` values", async () => {
     const key = "todos";
     const values = ["first", "second"];
-
     const { result } = renderHook(() =>
       useLocalState<string[] | undefined>(key, values)
     );
@@ -215,7 +218,6 @@ describe("useLocalState()", () => {
   it("can handle `null` values", async () => {
     const key = "todos";
     const values = ["first", "second"];
-
     const { result } = renderHook(() =>
       useLocalState<string[] | null>(key, values)
     );
@@ -230,11 +232,14 @@ describe("useLocalState()", () => {
   });
 
   it("can reset to default value", async () => {
+    if (!SUPPORTED) return;
+
     const key = "key";
     const value = "something";
-
     const { result } = renderHook(() => useLocalState(key, value));
-    expect(result.current[0]).toEqual(value);
+
+    const [initialValue] = result.current;
+    expect(initialValue).toEqual(value);
 
     const newValue = "something else";
     act(() => {
@@ -242,17 +247,16 @@ describe("useLocalState()", () => {
       setValue(newValue);
     });
 
-    const [changedValues] = result.current;
-    expect(changedValues).toEqual(newValue);
+    const [changedValue] = result.current;
+    expect(changedValue).toEqual(newValue);
 
     act(() => {
-      const reset = result.current[2];
-      reset();
+      const resetValue = result.current[2];
+      resetValue();
     });
 
-    const [values] = result.current;
-    expect(values).toEqual(value);
-
+    const [resetValue] = result.current;
+    expect(resetValue).toEqual(value);
     expect(localStorage.getItem(key)).toEqual(null);
   });
 
@@ -261,25 +265,26 @@ describe("useLocalState()", () => {
     const values = ["first", "second"];
     const callback = () => values;
     const { result } = renderHook(() => useLocalState(key, callback));
-    expect(result.current[0]).toEqual(values);
 
-    const newValue = ["third", "fourth"];
+    const [initialValues] = result.current;
+    expect(initialValues).toEqual(values);
+
+    const newValues = ["third", "fourth"];
     act(() => {
-      const setValue = result.current[1];
-      setValue(newValue);
+      const setValues = result.current[1];
+      setValues(newValues);
     });
 
     const [changedValues] = result.current;
-    expect(changedValues).toEqual(newValue);
+    expect(changedValues).toEqual(newValues);
 
     act(() => {
-      const reset = result.current[2];
-      reset();
+      const resetValues = result.current[2];
+      resetValues();
     });
 
     const [resetValues] = result.current;
     expect(resetValues).toEqual(values);
-
     expect(localStorage.getItem(key)).toEqual(null);
   });
 });

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -56,7 +56,7 @@ describe("useLocalState()", () => {
     expect(todos).toEqual(values);
   });
 
-  it("accepts callback as a value", async () => {
+  it("accepts callback as an initial value", async () => {
     const key = "todos";
     const values = ["first", "second"];
     const callback = () => values;
@@ -66,7 +66,7 @@ describe("useLocalState()", () => {
     expect(todos).toEqual(values);
   });
 
-  it("accepts callback as a defaultValue and can be updated with a simple type", async () => {
+  it("accepts callback as a initial value and can be updated", async () => {
     const key = "todos";
     const values = ["first", "second"];
     const callback = () => values;


### PR DESCRIPTION
Closes #2 
Closes #6 

Adds a 3rd item in the return array to reset the key. Is resets the key back to its `defaultValue` and clears the key within the LocalStorage.

This PR also fixes a bug where it was not type-safe to set a value after using a function as the `defaultValue`. The solution has been lifted from the React source code [here](https://github.com/facebook/react/blob/master/packages/react/src/ReactHooks.js). More information [here](https://medium.com/ableneo/typing-of-react-hooks-in-typescript-947b200fa0b0).

E.g.
```tsx
const [token, setToken] = useLocalState("token", () => "computed value");

// This line would raise a typescript error as `string` is not the same type as `() => S`;
setToken("ABC123");
```
